### PR TITLE
resolved 2x

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -48,7 +48,7 @@ const config = {
         text: 'Using the Invarion Cloud',
       },
       {
-        to: '/rapidplan-online/rapidplan-online-workspace/rapidplan-online-workspace',
+        to: '/rapidplan-online/rapidplan-online-workspace',
         text: 'The RapidPlan Online Workspace',
       },
       {
@@ -76,7 +76,7 @@ const config = {
         text: 'RP',
       },
       {
-        to: '/rapidplan-online/getting-started/getting-started',
+        to: '/rapidplan-online/getting-started',
         text: 'RO',
       },
 


### PR DESCRIPTION
RO homepage links resolved.
When linking to a single md file in a folder, it seems Docusaurus only accepts a link to the folder.
Eg. 
'rapidplan-online/rapidplan-online-workspace/rapidplan-online-workspace' doesn't work [folder and md file share the same name],
'rapidplan-online/rapidplan-online-workspace' does work.