### PR TITLE
Update RapidPlan 4.3.182 and 4.3.183 changelogs

### DIFF
--- a/docs/rapidplan/release-notes/02-hotfix.md
+++ b/docs/rapidplan/release-notes/02-hotfix.md
@@ -8,10 +8,11 @@ hide_title: true
 
 **The Hotfix channel is updated whenever any issues are reported and fixed - use it if you don't mind frequent application updates.**
 
-### Version 4.3.179 (19 May 2026)
+### Version 4.3.182 (19 May 2026)
 * Fixed purge base map tile cache issue.
 * Fixed cut custom symbol preview in PG.
 * Update OverpassAPI servers.
+* Fixed app startup issue caused by invalid system fonts.
 
 ### Version 4.3.166 (14 May 2026)
 * Prevent text editor disposal errors.

--- a/docs/rapidplan/release-notes/03-weekly.md
+++ b/docs/rapidplan/release-notes/03-weekly.md
@@ -10,7 +10,7 @@ hide_title: true
 
 _NOTE: all Weekly updates contain bugfixes published in the Hotfix channel, see separate changelog [HERE](/rapidplan/release-notes/hotfix/)._
 
-### Version 4.3.181 (19 May 2026)
+### Version 4.3.183 (19 May 2026)
 * Bugfixes.
 * Updated .Net runtime and libraries.
 * Reworked Send to layer dialog.


### PR DESCRIPTION
## Summary
- Update RapidPlan Hotfix changelog entry for 4.3.182 on 19 May 2026
- Add customer-facing note for the app startup fix caused by invalid system fonts
- Update RapidPlan Weekly changelog version to 4.3.183 for the same-date Weekly release

## Context
- Bugfix task: Invarion/DevTeamTasksRepo#2081
- Follows non-Stable channel changelog guidance: Hotfix lists the bugfix; Weekly keeps bugfix details summarized via the existing `Bugfixes` entry.