### PR TITLE
2123-lums-board-object-disappears-from-the-plan--changelog

### DIFF
--- a/docs/rapidplan/release-notes/02-hotfix.md
+++ b/docs/rapidplan/release-notes/02-hotfix.md
@@ -8,6 +8,9 @@ hide_title: true
 
 **The Hotfix channel is updated whenever any issues are reported and fixed - use it if you don't mind frequent application updates.**
 
+### Version 4.3.??? (03 June 2026)
+* Fixed LUMS board objects disappearing from the plan.
+
 ### Version 4.3.228 (02 June 2026)
 * Fixed chainage marker distance values at minimal spacing.
 * Fixed long tool names clipping in the Tools palette.

--- a/docs/rapidplan/release-notes/02-hotfix.md
+++ b/docs/rapidplan/release-notes/02-hotfix.md
@@ -8,7 +8,7 @@ hide_title: true
 
 **The Hotfix channel is updated whenever any issues are reported and fixed - use it if you don't mind frequent application updates.**
 
-### Version 4.3.??? (03 June 2026)
+### Version 4.3.223 (03 June 2026)
 * Fixed LUMS board objects disappearing from the plan.
 
 ### Version 4.3.228 (02 June 2026)

--- a/docs/rapidplan/release-notes/02-hotfix.md
+++ b/docs/rapidplan/release-notes/02-hotfix.md
@@ -9,7 +9,7 @@ hide_title: true
 **The Hotfix channel is updated whenever any issues are reported and fixed - use it if you don't mind frequent application updates.**
 
 ### Version 4.3.223 (03 June 2026)
-* Fixed LUMS board objects disappearing from the plan.
+* Preserve LUMS objects when artwork not available.
 
 ### Version 4.3.228 (02 June 2026)
 * Fixed chainage marker distance values at minimal spacing.

--- a/docs/rapidplan/release-notes/03-weekly.md
+++ b/docs/rapidplan/release-notes/03-weekly.md
@@ -10,9 +10,6 @@ hide_title: true
 
 _NOTE: all Weekly updates contain bugfixes published in the Hotfix channel, see separate changelog [HERE](/rapidplan/release-notes/hotfix/)._
 
-### Version 4.3.??? (03 June 2026)
-* Fixed LUMS board objects disappearing from the plan.
-
 ### Version 4.3.229 (02 June 2026)
 * Redesigned Spatial Data Import with ArcGIS Feature Service support.
 * Bugfixes.

--- a/docs/rapidplan/release-notes/03-weekly.md
+++ b/docs/rapidplan/release-notes/03-weekly.md
@@ -10,6 +10,9 @@ hide_title: true
 
 _NOTE: all Weekly updates contain bugfixes published in the Hotfix channel, see separate changelog [HERE](/rapidplan/release-notes/hotfix/)._
 
+### Version 4.3.??? (03 June 2026)
+* Fixed LUMS board objects disappearing from the plan.
+
 ### Version 4.3.229 (02 June 2026)
 * Redesigned Spatial Data Import with ArcGIS Feature Service support.
 * Bugfixes.


### PR DESCRIPTION
👾 *Agent-generated content* 👾

DTT: https://github.com/Invarion/DevTeamTasksRepo/issues/2123
Implementation PR: https://github.com/Invarion/RapidPlan/pull/3172

## Summary
- Add RapidPlan Hotfix and Weekly changelog entries for the LUMS board disappearance bugfix.
- Use 03 June 2026 and version placeholder 4.3.??? per RapidPlan changelog instructions.

## Review
- Please manually review before merging.