### PR TITLE
2123-lums-board-object-disappears-from-the-plan--changelog-version-fix

### DIFF
--- a/docs/rapidplan/release-notes/02-hotfix.md
+++ b/docs/rapidplan/release-notes/02-hotfix.md
@@ -8,7 +8,7 @@ hide_title: true
 
 **The Hotfix channel is updated whenever any issues are reported and fixed - use it if you don't mind frequent application updates.**
 
-### Version 4.3.223 (03 June 2026)
+### Version 4.3.233 (03 June 2026)
 * Preserve LUMS objects when artwork not available.
 
 ### Version 4.3.228 (02 June 2026)


### PR DESCRIPTION
👾 *Agent-generated content* 👾

DTT: https://github.com/Invarion/DevTeamTasksRepo/issues/2123
Prior changelog PR: https://github.com/Invarion/invarion-docs/pull/89
Implementation PR: https://github.com/Invarion/RapidPlan/pull/3172

## Summary
- Correct RapidPlan Hotfix changelog version for the DTT 2123 entry from 4.3.223 to 4.3.233.
- Weekly changelog remains unchanged for this bugfix.