### PR TITLE
RapidOnline release notes June 2026

### DIFF
--- a/docs/rapidplan-online/release-notes/release-notes-rapidplan-online.md
+++ b/docs/rapidplan-online/release-notes/release-notes-rapidplan-online.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 - Fixed an issue where some Scratchpad objects, including grouped objects and SVG-based items, could fail to appear on the plan or sync correctly after being added.
+- Fixed an issue where invalid swept path preview movements could cause an error instead of safely clearing the preview.
 
 ## May 2026
 

--- a/docs/rapidplan-online/release-notes/release-notes-rapidplan-online.md
+++ b/docs/rapidplan-online/release-notes/release-notes-rapidplan-online.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## June 2026
+
+### Bug fixes
+
+- Fixed an issue where some Scratchpad objects, including grouped objects and SVG-based items, could fail to appear on the plan or sync correctly after being added.
+
 ## May 2026
 
 - Fixed an issue where plans with a bearing value other than **0** could display differently in preview and export.

--- a/docs/rapidplan-online/release-notes/release-notes-rapidplan-online.md
+++ b/docs/rapidplan-online/release-notes/release-notes-rapidplan-online.md
@@ -5,7 +5,6 @@
 ### Bug fixes
 
 - Fixed an issue where some Scratchpad objects, including grouped objects and SVG-based items, could fail to appear on the plan or sync correctly after being added.
-- Fixed an issue where invalid swept path preview movements could cause an error instead of safely clearing the preview.
 
 ## May 2026
 


### PR DESCRIPTION
## Summary

Adds the June 2026 RapidOnline release notes entry for a customer-visible Scratchpad fix:

- Scratchpad objects could fail to appear on the plan or sync correctly after being added.

## Candidate reviewed but not added

- Swept path preview handling was reviewed as a possible customer-facing release note. The change prevents an invalid swept path preview from causing an error and instead clears the preview safely. It was not added to the published release notes because its release readiness/status is not final yet.

## Notes

- Generated from the current pre-release range in `Invarion/RapidOnline`.
- Opened as draft so the release note can be reviewed before merge.

Tests were not run as part of this documentation-only update.