### PR TITLE
RapidOnline release notes June 2026

### DIFF
--- a/docs/rapidplan-online/release-notes/release-notes-rapidplan-online.md
+++ b/docs/rapidplan-online/release-notes/release-notes-rapidplan-online.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## June 2026
+
+### Bug fixes
+
+- Fixed an issue where Scratchpad objects, including saved SVG items, could fail to sync after being placed on a plan.
+- Fixed an issue where changing the direction of arc roads and roundabouts did not update the object on the plan.
+- Fixed an issue where opacity settings were not applied correctly to object groups.
+
 ## May 2026
 
 - Fixed an issue where plans with a bearing value other than **0** could display differently in preview and export.


### PR DESCRIPTION
## Summary

Adds the June 2026 RapidOnline release notes entry for customer-visible fixes.

## Candidate reviewed but not added

- The invalid swept-path preview crash fix was identified as customer-visible, but no linked final Notion status was found, so it was left out of the published release notes.
- The broader DTO migration and property-grid test work was reviewed but excluded from public release notes because it is non-functional/internal or does not have a final customer-release status.
- Source PRs without linked or final release-note status were treated as warnings rather than public release-note entries.

## Notes

- Generated from the current pre-release range in `Invarion/RapidOnline`: `prod-1069..develop`.
- Opened as draft so the release note can be reviewed before merge.

Tests were not run as part of this documentation-only update.