### PR TITLE
RapidOnline release notes June 2026

### DIFF
--- a/docs/rapidplan-online/release-notes/release-notes-rapidplan-online.md
+++ b/docs/rapidplan-online/release-notes/release-notes-rapidplan-online.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## June 2026
+
+### Bug fixes
+
+- Fixed an issue where plans could fail to save after placing certain SVG objects from the Scratchpad.
+- Fixed an issue where turn lane point widths could produce incorrect results compared with RapidPlan.
+
 ## May 2026
 
 - Fixed an issue where plans with a bearing value other than **0** could display differently in preview and export.


### PR DESCRIPTION
## Summary

Adds the June 2026 RapidOnline release notes entry for customer-visible fixes.

## Notes

- Opened as draft so the release note can be reviewed before merge.
- Tests were not run as part of this documentation-only update.