### PR TITLE
RapidOnline release notes June 2026

### DIFF
--- a/docs/rapidplan-online/release-notes/release-notes-rapidplan-online.md
+++ b/docs/rapidplan-online/release-notes/release-notes-rapidplan-online.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## June 2026
+
+### Bug fixes
+
+- Fixed an issue where scratchpad objects were not normalized correctly, so objects placed from the scratchpad now preserve their data and behave more reliably.
+
 ## May 2026
 
 - Fixed an issue where plans with a bearing value other than **0** could display differently in preview and export.


### PR DESCRIPTION
## Summary

Adds the June 2026 RapidOnline release notes entry for a customer-visible scratchpad fix.

## Candidate reviewed but not added

These reviewed candidates were excluded from the public release notes because their readiness or final status was not available in the automation context.

- Invalid swept path preview: fixes a preview crash for certain reverse movements.
- DTO fixes: group DTO and sweep-direction changes that affect object editing and drawing behavior.

## Reviewer commands

- `@Codex include <candidate>` adds a matching candidate to the release notes.
- `@Codex remove <published note text>` removes a matching published release-note bullet.

## Notes

- Generated from the current pre-release range in `Invarion/RapidOnline`.
- Opened as draft because candidate status was not final for all reviewed changes.

Tests were not run as part of this documentation-only update.