### PR TITLE
RapidOnline release notes June 2026

### DIFF
--- a/docs/rapidplan-online/release-notes/release-notes-rapidplan-online.md
+++ b/docs/rapidplan-online/release-notes/release-notes-rapidplan-online.md
@@ -1,5 +1,7 @@
 # Release Notes
 
+## June 2026
+
 ## May 2026
 
 - Fixed an issue where plans with a bearing value other than **0** could display differently in preview and export.
@@ -453,7 +455,7 @@ One can show sign codes on the canvas. It can be enabled globally, per plan or i
 
 ### Progress dialog displayed when engine is booting
 
-Engine booting progress bar displayed to visualise load progress.
+Booting progress bar displayed to visualise load progress.
 
 ### New feature: Adjust Plan Location
 


### PR DESCRIPTION
## Summary

Adds the June 2026 RapidOnline release notes section and stages the current pre-release review.

## Candidate reviewed but not added

These customer-visible candidates were reviewed during release-note generation and can be added by reviewer instruction using `@Codex include <candidate>`.

- Scratchpad object updates and placement behavior: reviewed as customer-visible, but the linked task status is not in a final publishable state.
- Swept path preview stability for invalid reverse previews: reviewed as customer-visible, but no linked final Notion candidate was found.

## Reviewer commands

- `@Codex include <candidate>` adds a matching candidate to the release notes.
- `@Codex remove <published note text>` removes a matching published release-note bullet.

## Notes

- Generated from the current pre-release range in `Invarion/RapidOnline`.
- Opened as draft so the release note can be reviewed before merge.

Tests were not run as part of this documentation-only update.