### PR TITLE
RapidOnline release notes June 2026

### DIFF
--- a/docs/rapidplan-online/release-notes/release-notes-rapidplan-online.md
+++ b/docs/rapidplan-online/release-notes/release-notes-rapidplan-online.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## June 2026
+
+### Bug fixes
+
+- Fixed an issue where SVG objects from the Scratchpad could fail to save after being placed on a plan.
+- Fixed an issue where changing the direction of arc road and roundabout objects did not update the plan correctly.
+- Fixed an issue where object group opacity was not applied correctly.
+
 ## May 2026
 
 - Fixed an issue where plans with a bearing value other than **0** could display differently in preview and export.


### PR DESCRIPTION
## Summary

Adds the June 2026 RapidOnline release notes entry for customer-visible fixes.

## Candidate reviewed but not added

These customer-visible candidates were reviewed during release-note generation and can be added by reviewer instruction using `@Codex include <candidate>`.

- Arc drawing preview guide: reviewed as customer-visible, but the linked task status is not final.
- Swept path preview stability for invalid reverse previews: reviewed as customer-visible, but no linked final task was found.

## Reviewer commands

- `@Codex include <candidate>` adds a matching candidate to the release notes.
- `@Codex remove <published note text>` removes a matching published release-note bullet.

## Notes

- Generated from the current pre-release range in `Invarion/RapidOnline`.
- Opened as draft so the release note can be reviewed before merge.

Tests were not run as part of this documentation-only update.