### PR TITLE
RapidOnline release notes June 2026

### DIFF
--- a/docs/rapidplan-online/release-notes/release-notes-rapidplan-online.md
+++ b/docs/rapidplan-online/release-notes/release-notes-rapidplan-online.md
@@ -1,4 +1,4 @@
-﻿# Release Notes
+# Release Notes
 
 ## June 2026
 

--- a/docs/rapidplan-online/release-notes/release-notes-rapidplan-online.md
+++ b/docs/rapidplan-online/release-notes/release-notes-rapidplan-online.md
@@ -1,4 +1,10 @@
-# Release Notes
+﻿# Release Notes
+
+## June 2026
+
+### Bug fixes
+
+- Fixed an issue where complex scratchpad objects could fail to sync or appear incorrectly when added to a plan.
 
 ## May 2026
 


### PR DESCRIPTION
## Summary

Adds the June 2026 RapidOnline release notes entry for customer-visible fixes.

## Candidate reviewed but not added

These customer-visible candidates were reviewed during release-note generation and can be added by reviewer instruction using `@Codex include <candidate>`.

- Swept-path preview stability: Prevents a possible crash while previewing swept paths in certain reverse movements.

## Reviewer commands

- `@Codex include <candidate>` adds a matching candidate to the release notes.
- `@Codex remove <published note text>` removes a matching published release-note bullet.

## Notes

- Generated from the current pre-release range in `Invarion/RapidOnline`.
- Opened as draft so the release note can be reviewed before merge.

Tests were not run as part of this documentation-only update.