### PR TITLE
RapidOnline release notes June 2026

### DIFF
--- a/docs/rapidplan-online/release-notes/release-notes-rapidplan-online.md
+++ b/docs/rapidplan-online/release-notes/release-notes-rapidplan-online.md
@@ -443,7 +443,7 @@ One can now resize the size of the box, thus having a multi-column layout.
 
 ### Default paper sizes based on user's country
 
-Default paper size in print dialog is selected based on user license country.
+Default paper size in print dialog is selected based on the user license country.
 
 ### New feature: Object Styles
 

--- a/docs/rapidplan-online/release-notes/release-notes-rapidplan-online.md
+++ b/docs/rapidplan-online/release-notes/release-notes-rapidplan-online.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## June 2026
+
+### Bug fixes
+
+- Fixed an issue where placing certain Scratchpad items, including SVG-based objects, could cause plan saving to fail.
+
 ## May 2026
 
 - Fixed an issue where plans with a bearing value other than **0** could display differently in preview and export.
@@ -437,7 +443,7 @@ One can now resize the size of the box, thus having a multi-column layout.
 
 ### Default paper sizes based on user's country
 
-Default paper size in print dialog is selected based on the user license country.
+Default paper size in print dialog is selected based on user license country.
 
 ### New feature: Object Styles
 

--- a/docs/rapidplan-online/release-notes/release-notes-rapidplan-online.md
+++ b/docs/rapidplan-online/release-notes/release-notes-rapidplan-online.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 - Fixed an issue where placing certain Scratchpad items, including SVG-based objects, could cause plan saving to fail.
+- Restored the temporary guide line shown while drawing arc-based objects.
 
 ## May 2026
 


### PR DESCRIPTION
## Summary

Adds the June 2026 RapidOnline release notes entry for customer-visible fixes.

## Candidate reviewed but not added

These customer-visible candidates were reviewed during release-note generation and were not added automatically.

- Swept path preview stability: Prevents preview failures while drawing vehicle paths in certain reverse/forward movement cases.

## Reviewer changes

Request release-note changes in the original Codex chat that started this automation. GitHub PR comments are not supported for `include` or `remove` commands.

## Notes

- Generated from the current pre-release range in `Invarion/RapidOnline`.
- Opened as draft so the release note can be reviewed before merge.

Tests were not run as part of this documentation-only update.