### PR TITLE
RapidOnline release notes June 2026

### DIFF
--- a/docs/rapidplan-online/release-notes/release-notes-rapidplan-online.md
+++ b/docs/rapidplan-online/release-notes/release-notes-rapidplan-online.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## June 2026
+
+### Bug fixes
+
+- Arc roads now update correctly when you reverse their direction, so curved road layouts display the selected direction properly on the plan.
+- Scratchpad SVG objects can now be placed on a plan and saved without causing synchronization failures.
+
 ## May 2026
 
 - Fixed an issue where plans with a bearing value other than **0** could display differently in preview and export.


### PR DESCRIPTION
## Summary

Adds the June 2026 RapidOnline release notes entry for customer-visible fixes.

## Reviewer changes

Request release-note changes in the original Codex chat that started this automation. Do not leave release-note change requests as GitHub PR comments.

## Notes

- Generated from the current pre-release range in `Invarion/RapidOnline`.
- Opened as draft so the release note can be reviewed before merge.
- Additional reviewed candidates were intentionally not added automatically.

Tests were not run as part of this documentation-only update.