### PR TITLE
RapidOnline release notes June 2026

### DIFF
--- a/docs/rapidplan-online/release-notes/release-notes-rapidplan-online.md
+++ b/docs/rapidplan-online/release-notes/release-notes-rapidplan-online.md
@@ -5,6 +5,7 @@
 ### Bug fixes
 
 - Fixed an issue where plans could fail to save after adding certain SVG objects from the Scratchpad.
+- Fixed an issue where opacity settings for grouped objects could be lost or displayed incorrectly.
 
 ## May 2026
 

--- a/docs/rapidplan-online/release-notes/release-notes-rapidplan-online.md
+++ b/docs/rapidplan-online/release-notes/release-notes-rapidplan-online.md
@@ -2,6 +2,8 @@
 
 ## June 2026
 
+- Added a guide line while drawing arc objects, making it easier to position arc control points accurately.
+
 ### Bug fixes
 
 - Fixed an issue where plans could fail to save after adding certain SVG objects from the Scratchpad.

--- a/docs/rapidplan-online/release-notes/release-notes-rapidplan-online.md
+++ b/docs/rapidplan-online/release-notes/release-notes-rapidplan-online.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## June 2026
+
+### Bug fixes
+
+- Fixed an issue where plans could fail to save after adding certain SVG objects from the Scratchpad.
+
 ## May 2026
 
 - Fixed an issue where plans with a bearing value other than **0** could display differently in preview and export.


### PR DESCRIPTION
## Summary

Adds the June 2026 RapidOnline release notes entry for customer-visible fixes and improvements.

## Candidate reviewed but not added

These customer-visible candidates were reviewed during release-note generation and were not added automatically.

- Swept path preview stability: improves behavior for some invalid swept-path preview movements, but no linked final release candidate was found.

## Reviewer changes

Request release-note changes in the original Codex chat that started this automation. Do not leave release-note change requests as GitHub PR comments.

## Notes

- Generated from the current pre-release range in `Invarion/RapidOnline`.
- Opened as draft so the release note can be reviewed before merge.

Tests were not run as part of this documentation-only update.