### PR TITLE
RapidOnline release notes June 2026

### DIFF
--- a/docs/rapidplan-online/release-notes/release-notes-rapidplan-online.md
+++ b/docs/rapidplan-online/release-notes/release-notes-rapidplan-online.md
@@ -1,5 +1,16 @@
 # Release Notes
 
+## June 2026
+
+- Added a guide line while drawing arc objects, making it easier to place arcs accurately.
+- Improved object group settings so legend and manifest options, entry names, and opacity are handled more consistently.
+- Improved property grid fields for several objects, including rounded rectangles, callout boxes, location markers, and manifest-related settings.
+
+### Bug fixes
+
+- Fixed an issue where some reverse swept-path preview movements could cause the preview to stop working.
+- Fixed issues that could prevent arc direction and object group settings from being saved or restored correctly.
+
 ## May 2026
 
 - Fixed an issue where plans with a bearing value other than **0** could display differently in preview and export.


### PR DESCRIPTION
## Summary

Adds the June 2026 RapidOnline release notes entry for customer-visible fixes and improvements.

## Candidate reviewed but not added

These customer-visible candidates were reviewed during release-note generation and were not added automatically.

- Scratchpad object handling: Improvements to scratchpad object loading, rendering, normalization, and positioning were reviewed but not included in this release note update.
- Scratchpad startup loading: Loading scratchpad data when the editor opens was reviewed but not included in this release note update.
- Editor update reliability: Broader drawing update reliability improvements were reviewed but need separate confirmation before release-note publication.

## Reviewer changes

Request release-note changes in the original Codex chat that started this automation. Do not leave release-note change requests as GitHub PR comments.

## Notes

- Generated from the current pre-release range in `Invarion/RapidOnline`.
- Opened as draft so the release note can be reviewed before merge.

Tests were not run as part of this documentation-only update.