### PR TITLE
RapidOnline release notes July 2026

### DIFF
--- a/docs/rapidplan-online/release-notes/release-notes-rapidplan-online.md
+++ b/docs/rapidplan-online/release-notes/release-notes-rapidplan-online.md
@@ -1,5 +1,14 @@
 # Release Notes
 
+## July 2026
+
+- Added an arc guide line while drawing arcs, making it easier to place and shape arc objects accurately.
+
+### Bug fixes
+
+- Basemaps and PDF exports now respect non-zero plan bearings more consistently.
+- Swept path previews now handle invalid reverse movements without crashing.
+
 ## May 2026
 
 - Fixed an issue where plans with a bearing value other than **0** could display differently in preview and export.
@@ -451,7 +460,7 @@ One can show sign codes on the canvas. It can be enabled globally, per plan or i
 
 ## May 2023
 
-### Progress dialog displayed when engine is booting
+### Progress dialog displayed when engine booting
 
 Engine booting progress bar displayed to visualise load progress.
 

--- a/docs/rapidplan-online/release-notes/release-notes-rapidplan-online.md
+++ b/docs/rapidplan-online/release-notes/release-notes-rapidplan-online.md
@@ -460,7 +460,7 @@ One can show sign codes on the canvas. It can be enabled globally, per plan or i
 
 ## May 2023
 
-### Progress dialog displayed when engine booting
+### Progress dialog displayed when engine is booting
 
 Engine booting progress bar displayed to visualise load progress.
 


### PR DESCRIPTION
## Summary

Adds the July 2026 RapidOnline release notes entry for customer-visible fixes and an arc drawing improvement.

## Candidate reviewed but not added

These customer-visible candidates were reviewed during release-note generation and were not added automatically.

- Scratchpad and object placement reliability: object placement and transform behavior were reviewed but left out because readiness status was not final.
- Property grid and object settings behavior: object property and schema fixes were reviewed but left out because readiness status was not final.
- Print and print-region interaction improvements: additional print and print-region behavior was reviewed but left out because readiness status was not final.

## Reviewer changes

Request release-note changes in the original Codex chat that started this automation. Do not leave release-note change requests as GitHub PR comments.

## Notes

- Generated from the current pre-release range in `Invarion/RapidOnline`.
- Opened as draft because some reviewed candidates were not published and some published notes were approved in chat while source statuses were not final.

Tests were not run as part of this documentation-only update.