### PR TITLE
RapidOnline release notes August 2026

### DIFF
--- a/docs/rapidplan-online/release-notes/release-notes-rapidplan-online.md
+++ b/docs/rapidplan-online/release-notes/release-notes-rapidplan-online.md
@@ -2,6 +2,8 @@
 
 ## August 2026
 
+- Read-only plans can now be panned by dragging with the left mouse button or one finger, making navigation easier on desktop and touch devices.
+
 ### Bug fixes
 
 - Undoing changes while dragging a control point no longer causes RapidOnline to crash.

--- a/docs/rapidplan-online/release-notes/release-notes-rapidplan-online.md
+++ b/docs/rapidplan-online/release-notes/release-notes-rapidplan-online.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## August 2026
+
+### Bug fixes
+
+- Undoing changes while dragging a control point no longer causes RapidOnline to crash.
+
 ## July 2026
 
 - Added an arc guide line while drawing arcs, making it easier to place and shape arc objects accurately.


### PR DESCRIPTION
## Summary

Adds the August 2026 RapidOnline release notes entry for a customer-visible stability fix.

## Reviewer changes

Request release-note changes in the original Codex chat that started this automation. Do not leave release-note change requests as GitHub PR comments.

## Notes

- Generated from the current after-release shipped range.
- This is a documentation-only update.

Tests were not run as part of this documentation-only update.